### PR TITLE
consider inner classes in default value of "var" in <o:importConstants/>

### DIFF
--- a/src/main/java/org/omnifaces/taghandler/ImportConstants.java
+++ b/src/main/java/org/omnifaces/taghandler/ImportConstants.java
@@ -126,7 +126,13 @@ public class ImportConstants extends TagHandler {
 			CONSTANTS_CACHE.put(type, constants);
 		}
 
-		String var = varValue != null ? varValue : type.substring(type.lastIndexOf('.') + 1);
+		String var = varValue;
+		if(var == null){
+			int innerClass = type.lastIndexOf('$');
+			int outerClass = type.lastIndexOf('.');
+			int className = Math.max(innerClass, outerClass)
+			var = type.substring(className + 1);
+		}
 		context.getFacesContext().getExternalContext().getRequestMap().put(var, constants);
 	}
 


### PR DESCRIPTION
Currently the default value of the "var" for inner classes is i.e. "Outer$Inner". This change would changes this to only "Inner" any may break old code.
